### PR TITLE
Feat/render nutrients

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_URL = 'http://172.16.31.209:4000'
+REACT_APP_BACKEND_URL = 'http://localhost:4000'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8663,6 +8663,11 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -11366,6 +11371,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
+    "react-window": "^1.8.5",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "superagent": "^5.2.1"

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import './App.css';
 import { Switch, Route } from "react-router-dom";
 import Homepage from './components/Homepage'
 import UploadPage from './components/Uploadpage'
+import NutrientsPage from './components/NutrientsPage'
 import { appStyle } from './theme'
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
       <Switch>
         <Route path="/" exact component={Homepage} />
         <Route path="/upload" exact component={UploadPage} />
+        <Route path="/nutrient" exact component={NutrientsPage} />
       </Switch>
     </div>
   );

--- a/src/actions.js
+++ b/src/actions.js
@@ -50,7 +50,7 @@ const saveNutrients = nutrientObject => ({
 
 export const sendIngredients = (ingredientArray, imageName, jwt, push) => dispatch => {
   const data = { ingredients: ingredientArray, imageName }
-  request
+  return request
     .post(`${baseUrl}/ingredients`)
     .set('Authorization', `Bearer ${jwt}`)
     .send(data)
@@ -109,6 +109,19 @@ export const signUp = (username, password, email) => dispatch => {
     .send(data)
     .then(response => {
       dispatch(saveJWT(username, response.body.jwt))
+    })
+    .catch(console.error)
+}
+
+
+export const sendTitle = (recipeName, imageName, jwt) => () => {
+  const data = { recipeName, imageName }
+  return request
+    .post(`${baseUrl}/title`)
+    .set('Authorization', `Bearer ${jwt}`)
+    .send(data)
+    .then(response => {
+      console.log(response.body)
     })
     .catch(console.error)
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,6 +6,8 @@ export const SAVE_INGREDIENTS = 'SAVE_INGREDIENTS'
 
 export const ADD_INGREDIENT = 'ADD_INGREDIENT'
 
+export const CLEAR_INGREDIENTS = 'CLEAR_INGREDIENTS'
+
 export function saveIngredients(ingredientsArray) {
   return {
     type: SAVE_INGREDIENTS,
@@ -17,6 +19,12 @@ export function addIngredient(ingredient) {
   return {
     type: ADD_INGREDIENT,
     payload: ingredient
+  }
+}
+
+export function clearIngredients() {
+  return {
+    type: CLEAR_INGREDIENTS
   }
 }
 
@@ -113,15 +121,22 @@ export const signUp = (username, password, email) => dispatch => {
     .catch(console.error)
 }
 
+export const REDUCE_RECIPEARRAY = 'REDUCE_RECIPEARRAY'
 
-export const sendTitle = (recipeName, imageName, jwt) => () => {
+const reduceRecipeArray = title => ({
+  type: REDUCE_RECIPEARRAY,
+  payload: title
+})
+
+
+export const sendTitle = (recipeName, imageName, jwt) => dispatch => {
   const data = { recipeName, imageName }
   return request
     .post(`${baseUrl}/title`)
     .set('Authorization', `Bearer ${jwt}`)
     .send(data)
     .then(response => {
-      console.log(response.body)
+      dispatch(reduceRecipeArray(recipeName))
     })
     .catch(console.error)
 }

--- a/src/components/AddIngredient/RecipeNameModal.js
+++ b/src/components/AddIngredient/RecipeNameModal.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Fade, Backdrop, Modal, Typography, IconButton, Button, TextField } from '@material-ui/core'
+import { modalClass, modalStyle } from '../../theme'
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CancelIcon from '@material-ui/icons/Cancel';
+
+export default function RecipeNameModal(props) {
+  const [name, setName] = React.useState(props.recipes[0]['title']);
+  const [textfield, setTextfield] = React.useState('');
+  const onChange = event => {
+    setTextfield(event.target.value)
+  }
+  const nextName = () => {
+    const index = props.recipes.findIndex(recipe => recipe['title'] === name)
+    const newName = index === (props.recipes.length - 1) ? null : props.recipes[index + 1]['title']
+    setName(newName);
+  };
+
+  return (
+    <div>
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        style={modalClass}
+        open={props.modalOpen}
+        closeAfterTransition
+        BackdropComponent={Backdrop}
+        BackdropProps={{
+          timeout: 500,
+        }}
+      >
+        <Fade in={props.modalOpen}>
+          <div onSubmit={props.onSubmitIngredient} style={modalStyle}>
+            {name
+              ?
+              <div>
+                <Typography gutterBottom>
+                  Do you mean you had a {name} ?
+            </Typography>
+                <IconButton aria-label="yes" onClick={() => props.acceptRecipe(name)}>
+                  <CheckCircleIcon />
+                </IconButton>
+                <IconButton aria-label="no" onClick={nextName}>
+                  <CancelIcon />
+                </IconButton>
+              </div>
+              :
+              <div>
+                <Typography>
+                  Then I {`don't`} know <span role="img" aria-label="sadface">😕</span>
+                </Typography>
+                <Typography gutterBottom>
+                  Please tell me:
+                </Typography>
+                <TextField
+                  label="The recipe name"
+                  name="recipe"
+                  value={textfield}
+                  onChange={onChange}
+                  variant="outlined"
+                />
+                <Button
+                  onClick={() => props.acceptRecipe(textfield)}
+                >
+                  Set recipe name
+                </Button>
+              </div>
+            }
+          </div>
+        </Fade>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/AddIngredient/index.js
+++ b/src/components/AddIngredient/index.js
@@ -1,11 +1,17 @@
 import React, { Component } from 'react';
 import AddIngredient from './layout'
+import RecipeNameModal from './RecipeNameModal'
 import { connect } from 'react-redux'
-import { addIngredient, makeId, sendIngredients } from '../../actions'
+import { addIngredient, makeId, sendIngredients, sendTitle } from '../../actions'
 
 class AddIngredientContainer extends Component {
   state = {
-    ingredient: ''
+    ingredient: '',
+    modalOpen: false
+  }
+  acceptRecipe = title => {
+    this.props.dispatch(sendTitle(title, this.props.imageName, this.props.user.jwt))
+      .then(this.setState({ modalOpen: false }))
   }
   onChange = event => {
     this.setState({ [event.target.name]: event.target.value })
@@ -21,7 +27,8 @@ class AddIngredientContainer extends Component {
     this.setState({ ingredient: '' })
   }
   onSubmitRecipe = () => {
-    this.props.dispatch(sendIngredients(this.props.ingredients, this.props.imageName, this.props.user.jwt, this.props.history.push))
+    this.props.dispatch(sendIngredients(this.props.ingredients, this.props.imageName, this.props.user.jwt))
+      .then(this.setState({ modalOpen: true }))
   }
   render() {
     return (
@@ -33,6 +40,14 @@ class AddIngredientContainer extends Component {
           ingredient={this.state.ingredient}
           listOfIngredients={this.props.ingredients}
         />
+        {this.props.recipes.length > 0 &&
+          <RecipeNameModal
+            recipes={this.props.recipes}
+            modalOpen={this.state.modalOpen}
+            acceptRecipe={this.acceptRecipe}
+          />
+        }
+
       </div>
     );
   }
@@ -40,7 +55,8 @@ class AddIngredientContainer extends Component {
 
 const mapStateToProps = state => ({
   ingredients: state.ingredients,
-  user: state.currentUser
+  user: state.currentUser,
+  recipes: state.recipes
 })
 
 export default connect(mapStateToProps)(AddIngredientContainer);

--- a/src/components/AddIngredient/index.js
+++ b/src/components/AddIngredient/index.js
@@ -9,9 +9,11 @@ class AddIngredientContainer extends Component {
     ingredient: '',
     modalOpen: false
   }
-  acceptRecipe = title => {
-    this.props.dispatch(sendTitle(title, this.props.imageName, this.props.user.jwt))
-      .then(this.setState({ modalOpen: false }))
+  acceptRecipe = async title => {
+    await this.props.dispatch(sendTitle(title, this.props.imageName, this.props.user.jwt))
+    this.setState({ modalOpen: false })
+    this.props.setImageName('')
+    this.props.history.push('/nutrient')
   }
   onChange = event => {
     this.setState({ [event.target.name]: event.target.value })

--- a/src/components/Homepage/layout.js
+++ b/src/components/Homepage/layout.js
@@ -9,7 +9,7 @@ const Homepage = (props) => {
     <div>
       <Fade in={true}>
         <div>
-          <IconButton aria-label="logout" onClick={props.logOut}>
+          <IconButton aria-label="logout" onClick={props.logOut} className={classes.logOutBtn}>
             <ExitToAppIcon />
           </IconButton>
           <Typography variant="h2" className={classes.title}>

--- a/src/components/Homepage/style.js
+++ b/src/components/Homepage/style.js
@@ -10,5 +10,10 @@ export const useStyles = makeStyles(theme => ({
     paddingTop: '12vh',
     paddingLeft: '15vw',
     paddingRight: '15vw'
+  },
+  logOutBtn: {
+    position: 'absolute',
+    top: '1vh',
+    right: '1vw'
   }
 }))

--- a/src/components/Ingredients/layout.js
+++ b/src/components/Ingredients/layout.js
@@ -22,5 +22,3 @@ export default function Ingredients(props) {
     </div>
   );
 }
-//
-//

--- a/src/components/NutrientsPage/index.js
+++ b/src/components/NutrientsPage/index.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux'
+import NutrientsPage from './layout'
+import { clearIngredients } from '../../actions'
+
+class NutrientsContainer extends Component {
+  state = {
+    nutrients: {
+      Calories: {
+        amount: 555555,
+        percentOfDailyNeeds: 55,
+        unit: 'g'
+      }
+    }
+  }
+  onClick = page => {
+    this.props.dispatch(clearIngredients())
+    this.props.history.push(page)
+  }
+  componentDidMount() {
+    if (!this.props.user.jwt) {
+      this.props.history.push('/')
+    }
+  }
+  render() {
+    return (
+      <div>
+        <NutrientsPage
+          nutrients={this.props.nutrients}
+          recipes={this.props.recipes}
+          onClick={this.onClick}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  user: state.currentUser,
+  nutrients: state.nutrients,
+  recipes: state.recipes
+})
+
+export default connect(mapStateToProps)(NutrientsContainer);

--- a/src/components/NutrientsPage/layout.js
+++ b/src/components/NutrientsPage/layout.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Typography, Button } from '@material-ui/core'
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import { useStyles } from './styles'
+
+export default function NutrientsPage(props) {
+  const classes = useStyles();
+  const keyArray = Object.keys(props.nutrients)
+  const valueArray = Object.values(props.nutrients)
+  const title = props.recipes.length > 0 && props.recipes[0]['title']
+
+  const makeListStyle = percent => ({
+    background: `linear-gradient(to left, #a8e063, #1d170c)`,
+    backgroundSize: `${percent}% 20%`,
+    backgroundRepeat: "no-repeat",
+    backgroundPosition: "left bottom"
+  })
+
+  return (
+    <div>
+      <Typography variant="h5">
+        These are the nutritions you got from your {`${title}`}
+      </Typography>
+      <div className={classes.root}>
+        <List>
+          {keyArray.map((name, index) => (
+            <ListItem style={makeListStyle(valueArray[index]['percentOfDailyNeeds'])}>
+              <ListItemText
+                primary={<Typography>{name}</Typography>}
+                secondary={<Typography>{`${valueArray[index]['amount']} ${valueArray[index]['unit']}`}</Typography>}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </div>
+      <div className={classes.buttonContainer}>
+        <Button
+          onClick={() => props.onClick('/diary')}
+        >
+          See my diary
+      </Button>
+        <Button
+          onClick={() => props.onClick('/')}
+        >
+          Go to homepage
+      </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NutrientsPage/styles.js
+++ b/src/components/NutrientsPage/styles.js
@@ -1,0 +1,26 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles(theme => ({
+  root: {
+    width: '100%',
+    maxWidth: '60vw',
+    position: 'relative',
+    overflow: 'auto',
+    maxHeight: '40vh',
+    margin: '0 auto'
+  },
+  listSection: {
+    backgroundColor: 'inherit',
+  },
+  ul: {
+    backgroundColor: 'inherit',
+    padding: 0,
+  },
+  buttonContainer: {
+    display: 'flex',
+    justifyContent: 'space-around',
+    paddingTop: '6vh',
+    paddingLeft: '15vw',
+    paddingRight: '15vw'
+  },
+}));

--- a/src/components/Uploadpage.js
+++ b/src/components/Uploadpage.js
@@ -24,7 +24,7 @@ class Uploadpage extends Component {
           <div >
             {this.props.ingredients.length === 0 && <ImageUploader setImageName={this.setImageName} />}
             {this.props.ingredients.length > 0 && <Ingredients />}
-            {this.props.ingredients.length > 0 && <AddIngredient history={this.props.history} imageName={this.state.imageName} />}
+            {this.props.ingredients.length > 0 && <AddIngredient history={this.props.history} imageName={this.state.imageName} setImageName={this.setImageName} />}
           </div>
         </Zoom>
       </div>

--- a/src/reducers/ingredientsReducer.js
+++ b/src/reducers/ingredientsReducer.js
@@ -1,4 +1,4 @@
-import { SAVE_INGREDIENTS, ADD_INGREDIENT } from '../actions'
+import { SAVE_INGREDIENTS, ADD_INGREDIENT, CLEAR_INGREDIENTS } from '../actions'
 
 const initialState = []
 
@@ -8,6 +8,8 @@ export default function (state = initialState, action) {
       return [...action.payload]
     case ADD_INGREDIENT:
       return [action.payload, ...state]
+    case CLEAR_INGREDIENTS:
+      return initialState
     default:
       return state
   }

--- a/src/reducers/recipesReducer.js
+++ b/src/reducers/recipesReducer.js
@@ -1,4 +1,4 @@
-import { SAVE_RECIPE_NAMES } from '../actions'
+import { SAVE_RECIPE_NAMES, REDUCE_RECIPEARRAY } from '../actions'
 
 const initialState = []
 
@@ -6,6 +6,8 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case SAVE_RECIPE_NAMES:
       return [...action.payload]
+    case REDUCE_RECIPEARRAY:
+      return state.filter(recipe => recipe.title === action.payload)
     default:
       return state
   }

--- a/src/theme.js
+++ b/src/theme.js
@@ -37,9 +37,6 @@ export const theme = createMuiTheme({
     MuiIconButton: {
       root: {
         color: teal[500],
-        position: 'absolute',
-        top: '1vh',
-        right: '1vw'
       }
     },
     MuiChip: {


### PR DESCRIPTION
In this pull request I created a new route, /nutrients. The new component NutrientsPage is responsible for the rendering of this route, which contains the nutrition information from the recipe submitted. Before navigating to the /nutrients route the recipes slice reducer is updated with the chosen recipe. After leaving the nutrients route the ingredients slice reducer is emptied, this is to ensure that the user can upload a new image immediately after.

A new modal component was also added that lets the user decide on a recipe name based on the ingredients he submitted, which is then sent to the backend and updates the corresponding meals data in the database.